### PR TITLE
Fix incorrect variable name in sample

### DIFF
--- a/articles/cognitive-services/Bing-News-Search/go.md
+++ b/articles/cognitive-services/Bing-News-Search/go.md
@@ -147,7 +147,7 @@ resp, err := client.Do(req)
 defer resp.Body.Close()
 
 // Read the results
-resbody, err := ioutil.ReadAll(resp.Body)
+body, err := ioutil.ReadAll(resp.Body)
 if err != nil {
 	panic(err)
 }


### PR DESCRIPTION
Fix variable name mismatch (with line:164) based on the following sample go code.

https://github.com/MicrosoftDocs/azure-docs/blob/master/articles/cognitive-services/Bing-Web-Search/quickstarts/go.md